### PR TITLE
feat: add metada in ``PersistentPythonSession``

### DIFF
--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -82,6 +82,7 @@ class PersistentPythonSession:
         self._error_queue: queue.Queue = queue.Queue()
         self._is_running = False
         self._execution_lock = threading.Lock()
+        self.metadata: dict[str, Any] = {}
 
     def start(self) -> dict[str, Any]:
         """Start the persistent Python session.


### PR DESCRIPTION
This feature enables to connect the product session from the "normal" python session to the ``PersistentPythonSession`` and vice versa