### PR TITLE
fix: catch python errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           checkout: false
 
-  smoke-tests:
-    name: "Smoke tests ${{ matrix.python-version }} on ${{ matrix.os }}"
+  tests:
+    name: "Unit tests ${{ matrix.python-version }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     needs: [code-style]
     permissions:
@@ -66,7 +66,7 @@ jobs:
   package:
     name: "Package library"
     runs-on: ubuntu-latest
-    needs: [smoke-tests]
+    needs: [tests]
     permissions:
       contents: read
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = [
+tests = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tests = [
+dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",

--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -234,39 +234,38 @@ class PersistentPythonSession:
                             "error": error_msg,
                         }
 
-                    # Track if we got any data this iteration
-                    got_data = False
-
                     # Read from stdout
                     try:
-                        line = self._output_queue.get(timeout=0.1)
-                        got_data = True
-                        if marker in line:
-                            # Remove the marker line
-                            line = line.replace(marker, "").strip()
-                            if line:
-                                stdout_lines.append(line)
-                            marker_found = True
-                        else:
-                            stdout_lines.append(line.rstrip())
+                        output_line = self._output_queue.get(timeout=0.1)
                     except queue.Empty:
                         pass
+
+                    if output_line:
+                        if marker in output_line:
+                            # Remove the marker line
+                            output_line = output_line.replace(marker, "").strip()
+                            if output_line:
+                                stdout_lines.append(output_line)
+                            marker_found = True
+                        else:
+                            stdout_lines.append(output_line.rstrip())
 
                     # Read from stderr
                     try:
-                        line = self._error_queue.get(timeout=0.1)
-                        got_data = True
-                        stderr_lines.append(line.rstrip())
+                        error_line = self._error_queue.get(timeout=0.1)
                     except queue.Empty:
                         pass
 
+                    if error_line:
+                        stderr_lines.append(error_line.rstrip())
+
                     # If marker was found and no more data, we're done
-                    if marker_found and not got_data:
+                    if marker_found and not (error_line or output_line):
                         break
 
                     # Safety: if we've had many consecutive empty reads, break
                     # (This prevents infinite loops if marker is never found)
-                    if not got_data:
+                    if not (error_line or output_line):
                         consecutive_empty_reads += 1
                         if consecutive_empty_reads > 5:  # 5 * 0.1s = 0.5s of no data
                             if marker_found:
@@ -280,8 +279,8 @@ class PersistentPythonSession:
                         consecutive_empty_reads = 0
 
                 # After marker found, do one final drain of stderr to catch any remaining output
-                final_drain_start = __import__("time").time()
-                while __import__("time").time() - final_drain_start < 0.5:
+                final_drain_start = time.time()
+                while time.time() - final_drain_start < 0.5:
                     try:
                         line = self._error_queue.get(timeout=0.05)
                         stderr_lines.append(line.rstrip())

--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -209,6 +209,8 @@ class PersistentPythonSession:
                 stdout_lines = []
                 stderr_lines = []
                 start_time = __import__('time').time()
+                marker_found = False
+                consecutive_empty_reads = 0
 
                 while True:
                     elapsed = __import__('time').time() - start_time
@@ -222,25 +224,57 @@ class PersistentPythonSession:
                             "error": error_msg,
                         }
 
+                    # Track if we got any data this iteration
+                    got_data = False
+
                     # Read from stdout
                     try:
                         line = self._output_queue.get(timeout=0.1)
+                        got_data = True
                         if marker in line:
-                            # Remove the marker line and stop
+                            # Remove the marker line
                             line = line.replace(marker, "").strip()
                             if line:
                                 stdout_lines.append(line)
-                            break
-                        stdout_lines.append(line.rstrip())
+                            marker_found = True
+                        else:
+                            stdout_lines.append(line.rstrip())
                     except queue.Empty:
                         pass
 
                     # Read from stderr
                     try:
-                        line = self._error_queue.get(timeout=0.01)
+                        line = self._error_queue.get(timeout=0.1)
+                        got_data = True
                         stderr_lines.append(line.rstrip())
                     except queue.Empty:
                         pass
+
+                    # If marker was found and no more data, we're done
+                    if marker_found and not got_data:
+                        break
+                    
+                    # Safety: if we've had many consecutive empty reads, break
+                    # (This prevents infinite loops if marker is never found)
+                    if not got_data:
+                        consecutive_empty_reads += 1
+                        if consecutive_empty_reads > 5:  # 5 * 0.1s = 0.5s of no data
+                            if marker_found:
+                                break
+                            # If marker not found but no data, something went wrong
+                            logger.warning("No data received for extended period, stopping collection")
+                            break
+                    else:
+                        consecutive_empty_reads = 0
+
+                # After marker found, do one final drain of stderr to catch any remaining output
+                final_drain_start = __import__('time').time()
+                while __import__('time').time() - final_drain_start < 0.5:
+                    try:
+                        line = self._error_queue.get(timeout=0.05)
+                        stderr_lines.append(line.rstrip())
+                    except queue.Empty:
+                        break
 
                 stdout_text = "\n".join(stdout_lines)
                 stderr_text = "\n".join(stderr_lines)

--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -221,6 +221,7 @@ class PersistentPythonSession:
                         }
 
                     # Read from stdout
+                    output_line = None
                     try:
                         output_line = self._output_queue.get(timeout=0.1)
                     except queue.Empty:
@@ -237,6 +238,7 @@ class PersistentPythonSession:
                             stdout_lines.append(output_line.rstrip())
 
                     # Read from stderr
+                    error_line = None
                     try:
                         error_line = self._error_queue.get(timeout=0.1)
                     except queue.Empty:

--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -263,7 +263,7 @@ class PersistentPythonSession:
                     # If marker was found and no more data, we're done
                     if marker_found and not got_data:
                         break
-                    
+
                     # Safety: if we've had many consecutive empty reads, break
                     # (This prevents infinite loops if marker is never found)
                     if not got_data:
@@ -272,14 +272,16 @@ class PersistentPythonSession:
                             if marker_found:
                                 break
                             # If marker not found but no data, something went wrong
-                            logger.warning("No data received for extended period, stopping collection")
+                            logger.warning(
+                                "No data received for extended period, stopping collection"
+                            )
                             break
                     else:
                         consecutive_empty_reads = 0
 
                 # After marker found, do one final drain of stderr to catch any remaining output
-                final_drain_start = __import__('time').time()
-                while __import__('time').time() - final_drain_start < 0.5:
+                final_drain_start = __import__("time").time()
+                while __import__("time").time() - final_drain_start < 0.5:
                     try:
                         line = self._error_queue.get(timeout=0.05)
                         stderr_lines.append(line.rstrip())

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -321,9 +321,51 @@ class TestPersistentPythonSessionIntegration:
             session.stop()
 
     def test_execute_with_error(self):
-        """Test executing code that produces a runtime error."""
-        # TODO: This test will be implemented once the error handling will be in place.
-        pass
+        """Test executing code that produces a runtime error is properly caught."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Execute code that raises an error
+            result = session.execute("1/0")
+            assert not result["success"], "Error should be caught"
+            assert result["stderr"], "stderr should contain error info"
+            assert "error" in result["stderr"].lower() or "exception" in result["stderr"].lower()
+        finally:
+            session.stop()
+
+    def test_execute_with_syntax_error(self):
+        """Test executing code with syntax error is properly caught."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Execute code with syntax error
+            result = session.execute("if True print('bad syntax')")
+            assert not result["success"], "Syntax error should be caught"
+            assert result["stderr"], "stderr should contain error info"
+        finally:
+            session.stop()
+
+    def test_execute_multiline_with_error(self):
+        """Test executing multiline code where error occurs mid-execution."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            code = """
+x = 10
+y = 20
+z = x / 0
+"""
+            result = session.execute(code)
+            assert not result["success"], "Error should be caught"
+            assert "ZeroDivisionError" in result["stderr"] or "division by zero" in result["stderr"]
+        finally:
+            session.stop()
 
     def test_with_startup_code(self):
         """Test session with startup code that runs on initialization."""
@@ -412,5 +454,44 @@ class TestPersistentPythonSessionIntegration:
 
             # Metadata should still be accessible
             assert session.metadata["test_key"] == "test_value"
+        finally:
+            session.stop()
+
+    def test_stderr_collection_after_marker(self):
+        """Test that stderr is properly collected even after marker is found."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Execute code that writes to stderr after printing
+            code = """
+import sys
+print('stdout message')
+sys.stderr.write('stderr message\\n')
+"""
+            result = session.execute(code)
+            assert result["success"], f"Execution failed: {result.get('error')}"
+            assert "stdout message" in result["stdout"]
+            assert "stderr message" in result["stderr"]
+        finally:
+            session.stop()
+
+    def test_execute_with_warning(self):
+        """Test that Python warnings are captured in stderr."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Generate a deprecation warning
+            code = """
+import warnings
+warnings.warn('This is a test warning', DeprecationWarning)
+print('done')
+"""
+            result = session.execute(code)
+            # Warnings go to stderr but shouldn't fail execution
+            assert "done" in result["stdout"]
         finally:
             session.stop()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -360,6 +360,7 @@ class TestPersistentPythonSessionIntegration:
 x = 10
 y = 20
 z = x / 0
+print('hello')
 """
             result = session.execute(code)
             assert not result["success"], "Error should be caught"


### PR DESCRIPTION
Python errors were not correctly parsed by the stderr. This PR fixes this issue.


TODO:
- [x] add unit tests once #5 is merged