### PR TITLE
ci: missing CNAME on doc deploy actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
       - name: "Deploy the latest documentation"
         uses: ansys/actions/doc-deploy-dev@2a2b198b65c63adb69c0d032d180e4dc728d4809 #v10.2.9
         with:
+          cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
@@ -191,6 +192,7 @@ jobs:
       - name: "Deploy the stable documentation"
         uses: ansys/actions/doc-deploy-stable@2a2b198b65c63adb69c0d032d180e4dc728d4809 #v10.2.9
         with:
+          cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/doc/changelog.d/38.miscellaneous.md
+++ b/doc/changelog.d/38.miscellaneous.md
@@ -1,0 +1,1 @@
+Ci: missing CNAME on doc deploy actions


### PR DESCRIPTION
As title says - the default CNAME was still being used otherwise