### PR TITLE
ci: remove prefixes from fragments

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -130,6 +130,8 @@ jobs:
     - name: "Changelog fragment"
       uses: ansys/actions/doc-changelog@36cd86710c966963f4dcec56a9670171618cf76a # v10.2.4
       with:
+        use-pull-request-title: true
+        use-default-towncrier-config: true
         token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
         bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
         bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}

--- a/doc/changelog.d/26.maintenance.md
+++ b/doc/changelog.d/26.maintenance.md
@@ -1,1 +1,1 @@
-add changelog + update documentation
+Add changelog + update documentation

--- a/doc/changelog.d/26.maintenance.md
+++ b/doc/changelog.d/26.maintenance.md
@@ -1,1 +1,1 @@
-Feat: add changelog + update documentation
+add changelog + update documentation

--- a/doc/changelog.d/30.miscellaneous.md
+++ b/doc/changelog.d/30.miscellaneous.md
@@ -1,1 +1,1 @@
-Chore: missing replacement in CONTRIBUTING.md file
+Missing replacement in CONTRIBUTING.md file

--- a/doc/changelog.d/33.miscellaneous.md
+++ b/doc/changelog.d/33.miscellaneous.md
@@ -1,1 +1,1 @@
-Fix: README rendering
+README rendering

--- a/doc/changelog.d/37.miscellaneous.md
+++ b/doc/changelog.d/37.miscellaneous.md
@@ -1,1 +1,1 @@
-Chore: create CODEOWNERS
+Create CODEOWNERS

--- a/doc/changelog.d/39.maintenance.md
+++ b/doc/changelog.d/39.maintenance.md
@@ -1,0 +1,1 @@
+Remove prefixes from fragments


### PR DESCRIPTION
[OPTIONAL]

I see you are using labels for assigning categories for the fragments. I would recommend going through the conventional commit approach if you are fine with it - but ultimately it is your decision as the repository maintainer.

Using conventional commits allows you to get rid of the prefix assigned to the changelog fragments by default, and makes sure that they are placed in the proper category (label assignment is sometimes not ideal - but that's just my opinion 😄)