### PR TITLE
build: pinning down test dependencies

### DIFF
--- a/doc/changelog.d/40.dependencies.md
+++ b/doc/changelog.d/40.dependencies.md
@@ -1,0 +1,1 @@
+Pinning down test dependencies

--- a/doc/changelog.d/40.miscellaneous.md
+++ b/doc/changelog.d/40.miscellaneous.md
@@ -1,0 +1,1 @@
+Build: pinning down test dependencies

--- a/doc/changelog.d/40.miscellaneous.md
+++ b/doc/changelog.d/40.miscellaneous.md
@@ -1,1 +1,0 @@
-Build: pinning down test dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ tests = [
     "pytest-asyncio==1.3.0",
     "pytest-cov==7.0.0",
     "pytest-mock==3.15.1",
+    "mcp==1.26.0",
+    "fastmcp==3.1.1",
 ]
 doc = [
     "Sphinx==8.2.3",


### PR DESCRIPTION
I would suggest to pin them down so that you know which version of mcp and fastmcp you are running against when testing

With a lock file approach this is handled out-of-the-box but in this case.. I'd recommend fixing them