### PR TITLE
chore: dependabot proper ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "uv"
+  - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       - "maintenance"
       - "dependencies"
     commit-message:
-      prefix: "maint"
+      prefix: "build(pip)"
 
   - package-ecosystem: "github-actions"
     cooldown:
@@ -40,4 +40,4 @@ updates:
       - "maintenance"
       - "dependencies"
     commit-message:
-      prefix: "maint"
+      prefix: "build(actions)"

--- a/doc/changelog.d/48.maintenance.md
+++ b/doc/changelog.d/48.maintenance.md
@@ -1,0 +1,1 @@
+Dependabot proper ecosystem


### PR DESCRIPTION
Use the proper ecosystem for dependabot - unless you want to migrate to using ``uv`` (but in that case, more changes are needed)