### PR TITLE
feat: drop support to Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: "Run tests with pytest"
         uses: ansys/actions/tests-pytest@7419880d64bb0bba83f968ca803611df0b76faf0 #v10.3.4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyAnsys Common MCP
 
 [![PyAnsys](https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5+OQgMJ/0AqCqXGQMEBAwBEKQj5gGDjQsA80UeCDscxrD4YhGsgABEELnC5zAwAu6ADCKQDAQzNBFwAAVdgFEAnfDiQAATyIBaAFgCbkAI5DQwAVGAYkAMA4gHgg2AC+AAgQIABggagAqyAD4AF0MaB8gCbgoEAL0MEYRz4WxpMdWFzQBYKhK8DjEYH9KDgAw9ACAAgwFCgC2AMJvgAAJv+LQQJwJ8AAKQEoAAxr7W4AG/wGqAB4AACkR7cEdcEBQOPjIvAEtRDoAbYLANQAZGsBEAFeBwCsAY0HgGCAAEQTaDj7xQAABItJ+S3DsQAAAABJRU5ErkJggg==)](https://docs.pyansys.com/)
-[![Python](https://img.shields.io/badge/Python-3.12%2B-blue)](https://www.python.org/)
+[![Python](https://img.shields.io/pypi/pyversions/ansys-common-mcp?logo=pypi)](https://pypi.org/project/ansys-common-mcp)
 [![Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 PyAnsys Common MCP provides the infrastructure for building [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for PyAnsys libraries.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyAnsys Common MCP
 
 [![PyAnsys](https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5+OQgMJ/0AqCqXGQMEBAwBEKQj5gGDjQsA80UeCDscxrD4YhGsgABEELnC5zAwAu6ADCKQDAQzNBFwAAVdgFEAnfDiQAATyIBaAFgCbkAI5DQwAVGAYkAMA4gHgg2AC+AAgQIABggagAqyAD4AF0MaB8gCbgoEAL0MEYRz4WxpMdWFzQBYKhK8DjEYH9KDgAw9ACAAgwFCgC2AMJvgAAJv+LQQJwJ8AAKQEoAAxr7W4AG/wGqAB4AACkR7cEdcEBQOPjIvAEtRDoAbYLANQAZGsBEAFeBwCsAY0HgGCAAEQTaDj7xQAABItJ+S3DsQAAAABJRU5ErkJggg==)](https://docs.pyansys.com/)
-[![Python](https://img.shields.io/badge/Python-3.10%2B-blue)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12%2B-blue)](https://www.python.org/)
 [![Apache](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 PyAnsys Common MCP provides the infrastructure for building [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for PyAnsys libraries.
@@ -20,7 +20,7 @@ This package provides the foundation for creating MCP servers that enable AI ass
 
 ### For users
 
-The ``ansys.common.mcp`` package currently supports Python 3.10 through
+The ``ansys.common.mcp`` package currently supports Python 3.12 through
 Python 3.14 on Windows, Mac OS, and Linux.
 
 Install the latest package for use with this command:

--- a/doc/changelog.d/128.added.md
+++ b/doc/changelog.d/128.added.md
@@ -1,0 +1,1 @@
+Drop support to Python 3.10 and 3.11

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -21,13 +21,13 @@ Here are the requirements for PyAnsys Common MCP:
 
 Requirements
 ~~~~~~~~~~~~
-- Python 3.10 or later (up to 3.14)
+- Python 3.12 or later (up to 3.14)
 - A PyAnsys library for your product (such as PyMAPDL or PyFluent)
 
 Install in user mode
 ~~~~~~~~~~~~~~~~~~~~
 
-The ``ansys.common.mcp`` package currently supports Python 3.10 through
+The ``ansys.common.mcp`` package currently supports Python 3.12 through
 Python 3.14 on Windows, Mac OS, and Linux.
 
 Install the latest package for use with this command:

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyexample-mcp"
 version = "0.1.0"
 description = "MCP server for PyExample"
 readme = "README.md"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = { file = "LICENSE" }
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ansys-common-mcp"
 version = "0.4.dev0"
 description = "Common Model Context Protocol (MCP) server for PyAnsys libraries"
 readme = "README.md"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 authors = [
@@ -29,8 +29,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -117,7 +115,7 @@ lint.isort.known-first-party = [ "ansys.common.mcp" ]
 lint.pydocstyle.convention = "numpy"
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 strict = false
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
Fixes #113


Following the PyAnsys guidelines, this package needs to drop support to Python 3.10 and 3.11