### PR TITLE
feat: make check for consecutive empty reads timeout configurable

### DIFF
--- a/doc/changelog.d/129.added.md
+++ b/doc/changelog.d/129.added.md
@@ -1,0 +1,1 @@
+Make check for consecutive empty reads timeout configurable

--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -251,7 +251,9 @@ class PersistentPythonSession:
                 "error": error_msg,
             }
 
-    def execute(self, code: str, timeout: float = 30.0) -> dict[str, Any]:
+    def execute(
+        self, code: str, timeout: float = 30.0, max_consecutive_empty_reads: int = 5
+    ) -> dict[str, Any]:
         """Execute Python code in the persistent session.
 
         Parameters
@@ -260,6 +262,12 @@ class PersistentPythonSession:
             Python code to execute.
         timeout : float, default: 30.0
             Maximum execution time in seconds.
+        max_consecutive_empty_reads: int, default 5
+            Number of empty reads allowed before breaking out. Reads happen every ~0.2s, so
+            a value of 5 means allowing ~1.2s without any output written to stdout/stderr by
+            the code execution.
+            This prevents infinite loops if marker is never found.
+            Set to -1 to turn off this safety check.
 
         Returns
         -------
@@ -354,7 +362,12 @@ class PersistentPythonSession:
                     # (This prevents infinite loops if marker is never found)
                     if not (error_line or output_line):
                         consecutive_empty_reads += 1
-                        if consecutive_empty_reads > 5:  # 5 * 0.1s = 0.5s of no data
+                        if (
+                            max_consecutive_empty_reads > 0
+                            and consecutive_empty_reads > max_consecutive_empty_reads
+                        ):
+                            # for instance `max_consecutive_empty_reads=5` means
+                            # `(5+1) * (0.1s for stdout + 0.1s for stderr) = 1.2s` of no data
                             if marker_found:
                                 break
                             # If marker not found but no data, something went wrong

--- a/src/ansys/common/mcp/helpers.py
+++ b/src/ansys/common/mcp/helpers.py
@@ -252,7 +252,7 @@ class PersistentPythonSession:
             }
 
     def execute(
-        self, code: str, timeout: float = 30.0, max_consecutive_empty_reads: int = 5
+        self, code: str, timeout: float = 30.0, no_output_timeout: Optional[float] = 1.2
     ) -> dict[str, Any]:
         """Execute Python code in the persistent session.
 
@@ -262,12 +262,10 @@ class PersistentPythonSession:
             Python code to execute.
         timeout : float, default: 30.0
             Maximum execution time in seconds.
-        max_consecutive_empty_reads: int, default 5
-            Number of empty reads allowed before breaking out. Reads happen every ~0.2s, so
-            a value of 5 means allowing ~1.2s without any output written to stdout/stderr by
-            the code execution.
-            This prevents infinite loops if marker is never found.
-            Set to -1 to turn off this safety check.
+        no_output_timeout : float or None, default: 1.2
+            Maximum number of seconds to wait without receiving any output before
+            stopping collection. This prevents infinite loops if the completion
+            marker is never found. Set to ``None`` to disable this safety check.
 
         Returns
         -------
@@ -286,6 +284,15 @@ class PersistentPythonSession:
                 "stderr": "",
                 "error": "Session is not running. Call 'start()' first.",
             }
+
+        if no_output_timeout is not None and (
+            not isinstance(no_output_timeout, (int, float))
+            or no_output_timeout <= 0
+            or no_output_timeout != no_output_timeout  # NaN check
+        ):
+            raise ValueError(
+                f"no_output_timeout must be a positive number or None, got {no_output_timeout!r}."
+            )
 
         with self._execution_lock:
             try:
@@ -313,7 +320,7 @@ class PersistentPythonSession:
                 stderr_lines: list[str] = []
                 start_time = time.time()
                 marker_found = False
-                consecutive_empty_reads = 0
+                last_output_time = time.time()
 
                 while True:
                     elapsed = time.time() - start_time
@@ -358,25 +365,19 @@ class PersistentPythonSession:
                     if marker_found and not (error_line or output_line):
                         break
 
-                    # Safety: if we've had many consecutive empty reads, break
-                    # (This prevents infinite loops if marker is never found)
-                    if not (error_line or output_line):
-                        consecutive_empty_reads += 1
-                        if (
-                            max_consecutive_empty_reads > 0
-                            and consecutive_empty_reads > max_consecutive_empty_reads
-                        ):
-                            # for instance `max_consecutive_empty_reads=5` means
-                            # `(5+1) * (0.1s for stdout + 0.1s for stderr) = 1.2s` of no data
-                            if marker_found:
-                                break
-                            # If marker not found but no data, something went wrong
-                            logger.warning(
-                                "No data received for extended period. Stopping collection."
-                            )
+                    # Safety: if no output has been received for no_output_timeout seconds,
+                    # stop collection to prevent infinite loops if the marker is never found.
+                    if error_line or output_line:
+                        last_output_time = time.time()
+                    elif (
+                        no_output_timeout is not None
+                        and time.time() - last_output_time > no_output_timeout
+                    ):
+                        if marker_found:
                             break
-                    else:
-                        consecutive_empty_reads = 0
+                        # Marker not found but no data: something went wrong
+                        logger.warning("No data received for extended period. Stopping collection.")
+                        break
 
                 # After marker found, do one final drain of stderr to catch any remaining output
                 final_drain_start = time.time()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -544,3 +544,68 @@ print('done')
             assert "done" in result["stdout"]
         finally:
             session.stop()
+
+    def test_empty_reads_default_timeout(self):
+        """Test that the default timeout (~1.2s) for empty reads fires as expected."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Blocks output to stdout for longer than the timeout
+            code = """
+import time
+time.sleep(1.4)
+print('done')
+"""
+            result = session.execute(code)
+
+            # Check interrupted before printing 'done'
+            assert "done" not in result["stdout"]
+
+        finally:
+            session.stop()
+
+    def test_disable_empty_reads_default_timeout(self):
+        """Test that the default timeout (~1s) for empty reads can be disabled."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Blocks output to stdout
+            code = """
+import time
+time.sleep(1.4)
+print('done')
+"""
+            # max_consecutive_empty_reads=-1 turns off time-out
+            result = session.execute(code, max_consecutive_empty_reads=-1)
+
+            # Check not interrupted and both values printed
+            assert "done" in result["stdout"]
+
+        finally:
+            session.stop()
+
+    def test_custom_empty_reads_default_timeout(self):
+        """Test that a custom timeout for empty reads is applied."""
+        session = PersistentPythonSession()
+
+        try:
+            session.start()
+
+            # Blocks output to stdout
+            code = """
+import time
+time.sleep(1)
+print('done')
+"""
+            # max_consecutive_empty_reads=2 sets the time-out to ~0.6s
+            result = session.execute(code, max_consecutive_empty_reads=2)
+
+            # Check interrupted before printing 'done'
+            assert "done" not in result["stdout"]
+
+        finally:
+            session.stop()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -545,67 +545,77 @@ print('done')
         finally:
             session.stop()
 
-    def test_empty_reads_default_timeout(self):
-        """Test that the default timeout (~1.2s) for empty reads fires as expected."""
+    def test_no_output_timeout_fires_by_default(self):
+        """Test that the default no_output_timeout (1.2s) interrupts code with no output."""
         session = PersistentPythonSession()
 
         try:
             session.start()
 
-            # Blocks output to stdout for longer than the timeout
+            # Sleeps well beyond the default 1.2s idle timeout without producing output
             code = """
 import time
-time.sleep(1.4)
+time.sleep(3)
 print('done')
 """
             result = session.execute(code)
 
-            # Check interrupted before printing 'done'
+            # Execution should be interrupted before 'done' is printed
             assert "done" not in result["stdout"]
 
         finally:
             session.stop()
 
-    def test_disable_empty_reads_default_timeout(self):
-        """Test that the default timeout (~1s) for empty reads can be disabled."""
+    def test_no_output_timeout_can_be_disabled(self):
+        """Test that setting no_output_timeout=None disables the idle check."""
         session = PersistentPythonSession()
 
         try:
             session.start()
 
-            # Blocks output to stdout
+            # Sleeps briefly, but longer than the default 1.2s idle timeout
             code = """
 import time
 time.sleep(1.4)
 print('done')
 """
-            # max_consecutive_empty_reads=-1 turns off time-out
-            result = session.execute(code, max_consecutive_empty_reads=-1)
+            # no_output_timeout=None disables the check; rely on the outer timeout instead
+            result = session.execute(code, no_output_timeout=None)
 
-            # Check not interrupted and both values printed
             assert "done" in result["stdout"]
 
         finally:
             session.stop()
 
-    def test_custom_empty_reads_default_timeout(self):
-        """Test that a custom timeout for empty reads is applied."""
+    def test_no_output_timeout_custom_value(self):
+        """Test that a custom no_output_timeout is respected."""
         session = PersistentPythonSession()
 
         try:
             session.start()
 
-            # Blocks output to stdout
+            # Sleeps longer than the custom timeout but shorter than the default
             code = """
 import time
 time.sleep(1)
 print('done')
 """
-            # max_consecutive_empty_reads=2 sets the time-out to ~0.6s
-            result = session.execute(code, max_consecutive_empty_reads=2)
+            # 0.5s idle timeout should fire before the 1s sleep finishes
+            result = session.execute(code, no_output_timeout=0.5)
 
-            # Check interrupted before printing 'done'
             assert "done" not in result["stdout"]
 
+        finally:
+            session.stop()
+
+    def test_no_output_timeout_invalid_values(self):
+        """Test that invalid no_output_timeout values raise ValueError."""
+        session = PersistentPythonSession()
+        session.start()
+
+        try:
+            for bad_value in (0, -1, float("nan"), float("-inf"), "5"):
+                with pytest.raises(ValueError, match="no_output_timeout"):
+                    session.execute("print('hi')", no_output_timeout=bad_value)
         finally:
             session.stop()


### PR DESCRIPTION
In our use case, a line of Python code can trigger computations that might take a while. When that happens, the [check for too many consecutive empty reads](https://github.com/ansys/pyansys-common-mcp/blob/c68a2d8b504e9a83ca0473d255c49e780799cedb/src/ansys/common/mcp/helpers.py#L357) triggers, and the execution is interrupted. Currently, we are working around the issue by having a copy of [execute](https://github.com/ansys/pyansys-common-mcp/blob/c68a2d8b504e9a83ca0473d255c49e780799cedb/src/ansys/common/mcp/helpers.py#L254) in our derived class with that check removed. 

If the maximum value was exposed, it would allow to configure the time-out and avoid the code duplication in the derived class in our use case. Not sure if there are better ways to handle this case.



