### PR TITLE
feat: add configurable HTTP transport via CLI

### DIFF
--- a/doc/changelog.d/130.added.md
+++ b/doc/changelog.d/130.added.md
@@ -1,0 +1,1 @@
+Add configurable HTTP transport via CLI

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,14 +45,17 @@ html_theme_options = {
             "icon": "fa fa-comment fa-fw",
         },
     ],
-    "switcher": {
-        "json_url": f"https://{cname}/versions.json",
-        "version_match": switcher_version,
-    },
     "ansys_sphinx_theme_autoapi": {
         "project": project,
     },
 }
+
+if os.getenv("DOCUMENTATION_HAS_VERSION_SWITCHER"):
+    cname = os.getenv("DOCUMENTATION_CNAME", "cfx-mcp.docs.pyansys.com")
+    html_theme_options["switcher"] = {
+        "json_url": f"https://{cname}/versions.json",
+        "version_match": switcher_version,
+    }
 
 html_context = {
     "display_github": True,  # Integrate GitHub

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -51,7 +51,7 @@ html_theme_options = {
 }
 
 if os.getenv("DOCUMENTATION_HAS_VERSION_SWITCHER"):
-    cname = os.getenv("DOCUMENTATION_CNAME", "cfx-mcp.docs.pyansys.com")
+    cname = os.getenv("DOCUMENTATION_CNAME", "common-mcp.docs.pyansys.com")
     html_theme_options["switcher"] = {
         "json_url": f"https://{cname}/versions.json",
         "version_match": switcher_version,

--- a/doc/source/examples/pyexample_mcp.rst
+++ b/doc/source/examples/pyexample_mcp.rst
@@ -91,6 +91,32 @@ Define the entry point
 .. literalinclude:: ../../../examples/src/pyexample_mcp/__main__.py
    :language: python
 
+The entry point delegates transport selection entirely to
+:meth:`~ansys.common.mcp.server.PyAnsysBaseMCP.run_cli`, which is provided by the base
+class. You do not need to implement argument parsing or transport dispatch yourself.
+
+``run_cli()`` accepts the following command-line arguments:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 15 60
+
+   * - Argument
+     - Default
+     - Description
+   * - ``--transport {stdio,http}``
+     - ``stdio``
+     - Transport protocol to use.
+   * - ``--http-host HOST``
+     - ``127.0.0.1``
+     - Host address when using HTTP transport.
+   * - ``--http-port PORT``
+     - ``8080``
+     - Port number when using HTTP transport (1–65535).
+   * - ``--cors-origins ORIGINS``
+     - *(none)*
+     - Comma-separated list of allowed CORS origins for HTTP transport.
+
 
 Configure the package
 ---------------------
@@ -111,27 +137,70 @@ Install the package in a virtual environment using pip:
    pip install .
 
 
-Then, start the server using the entry point:
+Start the server with the default stdio transport:
 
 .. code-block:: bash
 
    python -m pyexample_mcp
 
 
-Another option is to configure the server in VS Code for easier development and debugging. Create a file
-``.vscode/mcp.json`` with the following content:
+Start the server with HTTP transport on the default host and port (``127.0.0.1:8080``):
+
+.. code-block:: bash
+
+   python -m pyexample_mcp --transport http
+
+
+Customize the host, port, and allowed CORS origins:
+
+.. code-block:: bash
+
+   python -m pyexample_mcp --transport http \
+       --http-host 0.0.0.0 \
+       --http-port 9000 \
+       --cors-origins "http://localhost:3000,https://myapp.com"
+
+
+VS Code configuration
+~~~~~~~~~~~~~~~~~~~~~
+
+For easier development and debugging, configure the server in VS Code by creating
+a ``.vscode/mcp.json`` file.
+
+Stdio transport (default):
 
 .. code-block:: json
 
    {
-	   "servers": {
-		   "pyexample-mcp": {
-			   "type": "stdio",
-			   "command": ".\\.venv\\Scripts\\python.exe",
-			   "args": ["-m", "pyexample_mcp"]
-	       }
-	   }
+       "servers": {
+           "pyexample-mcp": {
+               "type": "stdio",
+               "command": ".\\.venv\\Scripts\\python.exe",
+               "args": ["-m", "pyexample_mcp"]
+           }
+       }
    }
 
 
-The server will start and communicate via stdio, ready to accept MCP requests from AI clients.
+HTTP transport:
+
+.. code-block:: json
+
+   {
+       "servers": {
+           "pyexample-mcp": {
+               "type": "http",
+               "url": "http://127.0.0.1:8080/mcp"
+           }
+       }
+   }
+
+When using HTTP transport, start the server process separately before connecting VS Code:
+
+.. code-block:: bash
+
+   python -m pyexample_mcp --transport http
+
+
+The server will start and communicate via the selected transport, ready to accept MCP requests
+from AI clients.

--- a/doc/source/user_guide/advanced_patterns.rst
+++ b/doc/source/user_guide/advanced_patterns.rst
@@ -297,6 +297,103 @@ Manage user preferences
            return f"Preference '{key}' is not set."
        return value
 
+Configure the transport protocol
+================================
+
+By default, MCP servers communicate over stdio, which is the standard transport
+for local AI client integrations. The base class also supports HTTP transport,
+which is useful for remote clients, web applications, and CORS-enabled frontends.
+
+The :meth:`~ansys.common.mcp.server.PyAnsysBaseMCP.run_cli` method handles all transport
+configuration. Call it from your package's ``__main__.py`` instead of
+calling ``app.run()`` directly:
+
+.. code-block:: python
+
+   # src/myproduct_mcp/__main__.py
+   import sys
+   from ansys.common.mcp.logging_config import setup_logging
+   from myproduct_mcp import app
+   import myproduct_mcp.tools  # noqa: F401
+
+   def main(argv=None):
+       setup_logging(level="INFO")
+       app.run_cli(argv)  # transport, host, port, and CORS are handled here
+       return 0
+
+   if __name__ == "__main__":
+       sys.exit(main())
+
+Your users can then select the transport at startup without any additional code in your
+package:
+
+.. code-block:: bash
+
+   # stdio (default)
+   python -m myproduct_mcp
+
+   # HTTP on the default address (127.0.0.1:8080)
+   python -m myproduct_mcp --transport http
+
+   # HTTP with a custom host and port
+   python -m myproduct_mcp --transport http --http-host 0.0.0.0 --http-port 9000
+
+   # HTTP with CORS origins
+   python -m myproduct_mcp --transport http \\
+       --cors-origins "http://localhost:3000,https://myapp.com"
+
+.. note::
+
+   HTTP transport uses streamable HTTP (``/mcp`` endpoint). When using the HTTP
+   transport, start the server process first, then point your AI client at
+   ``http://<host>:<port>/mcp``.
+
+Add product-specific CLI arguments
+-----------------------------------
+
+For products that need their own CLI arguments (for example, a connection IP or port),
+override :meth:`~ansys.common.mcp.server.PyAnsysBaseMCP._add_cli_arguments` to inject
+them into the parser, and
+:meth:`~ansys.common.mcp.server.PyAnsysBaseMCP._configure_from_cli` to process them.
+The transport dispatch is unchanged — you never need to rewrite it.
+
+Add arguments to the parser:
+
+.. literalinclude:: ../../../examples/src/pyexample_mcp/server.py
+   :language: python
+   :pyobject: PyExampleMCP._add_cli_arguments
+
+Store the parsed values before the server starts:
+
+.. literalinclude:: ../../../examples/src/pyexample_mcp/server.py
+   :language: python
+   :pyobject: PyExampleMCP._configure_from_cli
+
+The resulting server now accepts both the standard transport arguments and the
+product-specific ones:
+
+.. code-block:: bash
+
+   python -m pyexample_mcp --ip 10.0.0.5 --port 50052 --connect-on-startup
+   python -m pyexample_mcp --transport http --http-port 9000 --ip 10.0.0.5
+
+Test CLI argument parsing
+-------------------------
+
+Because ``run_cli()`` accepts an optional ``argv`` list, you can test CLI argument
+parsing without starting a real server. Tests for transport and CORS:
+
+.. literalinclude:: ../../../tests/test_pyexample/test_main.py
+   :language: python
+   :pyobject: TestMainCliDispatch
+
+Tests for product-specific arguments:
+
+.. literalinclude:: ../../../tests/test_pyexample/test_main.py
+   :language: python
+   :pyobject: TestPyExampleCliHooks
+
+
 Expose tool sets
 ================
 

--- a/doc/source/user_guide/advanced_patterns.rst
+++ b/doc/source/user_guide/advanced_patterns.rst
@@ -349,7 +349,7 @@ package:
    ``http://<host>:<port>/mcp``.
 
 Add product-specific CLI arguments
------------------------------------
+----------------------------------
 
 For products that need their own CLI arguments (for example, a connection IP or port),
 override :meth:`~ansys.common.mcp.server.PyAnsysBaseMCP._add_cli_arguments` to inject

--- a/examples/pyproject.toml
+++ b/examples/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyexample-mcp"
 version = "0.1.0"
 description = "MCP server for PyExample"
 readme = "README.md"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = { file = "LICENSE" }
 
 dependencies = [

--- a/examples/src/pyexample_mcp/__main__.py
+++ b/examples/src/pyexample_mcp/__main__.py
@@ -25,13 +25,14 @@ from pyexample_mcp import app
 import pyexample_mcp.tools  # noqa: F401
 
 
-def main():
+def main(argv=None):
     """Run the PyExample MCP server."""
     # Setup logging
     setup_logging(level="INFO")
 
-    # Run the server (app instance already has tools registered)
-    app.run()
+    # Run the server using the base-class CLI handler.
+    # Supports --transport stdio|http, --http-host, --http-port, --cors-origins.
+    app.run_cli(argv)
 
     return 0
 

--- a/examples/src/pyexample_mcp/server.py
+++ b/examples/src/pyexample_mcp/server.py
@@ -16,6 +16,8 @@
 
 """MCP server for PyExample."""
 
+import argparse
+
 from ansys.common.mcp import PersistentPythonSession, PyAnsysBaseMCP
 from ansys.common.mcp.logging_config import get_logger
 from pyexample_mcp.context import PyExampleContext
@@ -115,6 +117,52 @@ print("PyExample MCP session initialized")
                 logger.info("PyExample instance closed successfully")
             except Exception as e:
                 logger.error(f"Error during PyExample cleanup: {e}")
+
+    def _add_cli_arguments(self, parser: argparse.ArgumentParser) -> None:
+        """Add PyExample-specific CLI arguments.
+
+        Parameters
+        ----------
+        parser : argparse.ArgumentParser
+            Argument parser pre-populated with the standard transport arguments.
+            Add product-specific arguments directly to it.
+
+        """
+        parser.add_argument(
+            "--ip",
+            dest="example_ip",
+            default="127.0.0.1",
+            help="PyExample server IP or hostname.",
+        )
+        parser.add_argument(
+            "--port",
+            dest="example_port",
+            type=int,
+            default=50052,
+            help="PyExample gRPC port.",
+        )
+        parser.add_argument(
+            "--connect-on-startup",
+            dest="connect_on_startup",
+            action="store_true",
+            help="Connect to PyExample during MCP startup.",
+        )
+
+    def _configure_from_cli(self, args: argparse.Namespace) -> None:
+        """Store parsed PyExample CLI arguments before the server starts.
+
+        Parameters
+        ----------
+        args : argparse.Namespace
+            Fully parsed namespace containing both standard transport arguments
+            and the product-specific arguments added by :meth:`_add_cli_arguments`.
+
+        """
+        self._cli_config = {
+            "example_ip": args.example_ip,
+            "example_port": args.example_port,
+            "connect_on_startup": args.connect_on_startup,
+        }
 
 
 # Create the MCP server instance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ansys-common-mcp"
 version = "0.4.dev0"
 description = "Common Model Context Protocol (MCP) server for PyAnsys libraries"
 readme = "README.md"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ doc = [
     "flit>=3.8.0",
     "inflect==7.5.0",
     "jupyter_sphinx==0.5.3",
-    "numpy==2.2.6",
+    "numpy==2.5.1",
     "numpydoc==1.10.0",
     "pandas==2.3.3",
     "parse==1.22.1",

--- a/src/ansys/common/mcp/server.py
+++ b/src/ansys/common/mcp/server.py
@@ -21,13 +21,43 @@ servers can extend to create their own MCP implementations.
 """
 
 from abc import ABC, abstractmethod
+import argparse
+import asyncio
 from contextlib import asynccontextmanager
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, List, Optional
 
 from fastmcp import FastMCP
 
 from ansys.common.mcp.context import PyAnsysBaseAppContext
 from ansys.common.mcp.helpers import PersistentPythonSession, logger
+
+
+def _validate_port(value: str) -> int:
+    """Validate that *value* is an integer in the valid port range 1-65535.
+
+    Parameters
+    ----------
+    value : str
+        String representation of the port number to validate.
+
+    Returns
+    -------
+    int
+        The validated port number.
+
+    Raises
+    ------
+    argparse.ArgumentTypeError
+        If the value is not a valid integer or is outside the range 1-65535.
+
+    """
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Port must be an integer, got: {value!r}")
+    if port < 1 or port > 65535:
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got: {port}")
+    return port
 
 
 class PyAnsysBaseMCP(FastMCP, ABC):
@@ -63,6 +93,7 @@ class PyAnsysBaseMCP(FastMCP, ABC):
         self.python_executable = python_executable
         self.working_directory = working_directory
         self._need_python = need_python
+        self._cli_config: dict = {}
 
         super().__init__(*args, lifespan=self.product_lifespan, **kwargs)
 
@@ -270,3 +301,168 @@ print("PyVista configured for off-screen rendering.")
             if self._need_python:
                 self.cleanup_python_session()
             self.product_cleanup()
+
+    def run_cli(self, argv: Optional[List[str]] = None) -> None:
+        """Parse CLI arguments and run the MCP server with the selected transport.
+
+        This method provides a ready-to-use entry point for product-specific MCP
+        servers, handling transport selection and HTTP configuration so that
+        downstream packages do not need to duplicate this boilerplate.
+
+        The method follows the **template method pattern**: two hooks let subclasses
+        extend the CLI without rewriting the transport dispatch logic:
+
+        - :meth:`_add_cli_arguments` — add product-specific arguments to the parser.
+        - :meth:`_configure_from_cli` — process parsed product-specific arguments
+          (for example, store them in ``_cli_config`` so ``create_context`` can read them).
+
+        Parameters
+        ----------
+        argv : list[str] or None, default: None
+            Argument list to parse. If ``None``, ``sys.argv[1:]`` is used.
+            Pass an explicit list in tests to avoid reading the real command line.
+
+        Examples
+        --------
+        Minimal usage — call from a product's ``__main__.py``:
+
+        >>> app.run_cli()
+
+        Product with extra CLI arguments:
+
+        >>> class PyMAPDLMCP(PyAnsysBaseMCP):
+        ...     def _add_cli_arguments(self, parser):
+        ...         parser.add_argument("--ip", dest="mapdl_ip", default="127.0.0.1")
+        ...         parser.add_argument("--port", dest="mapdl_port", type=int, default=50052)
+        ...
+        ...     def _configure_from_cli(self, args):
+        ...         self._cli_config = {"mapdl_ip": args.mapdl_ip, "mapdl_port": args.mapdl_port}
+
+        """
+        parser = argparse.ArgumentParser(
+            description="Run the MCP server.",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        )
+        parser.add_argument(
+            "--transport",
+            dest="transport",
+            choices=["stdio", "http"],
+            default="stdio",
+            help="Transport protocol for the MCP server.",
+        )
+        parser.add_argument(
+            "--http-host",
+            dest="http_host",
+            default="127.0.0.1",
+            help="Host address for HTTP transport.",
+        )
+        parser.add_argument(
+            "--http-port",
+            dest="http_port",
+            type=_validate_port,
+            default=8080,
+            help="Port number for HTTP transport (1-65535).",
+        )
+        parser.add_argument(
+            "--cors-origins",
+            dest="cors_origins",
+            default=None,
+            help="Comma-separated list of allowed CORS origins for HTTP transport.",
+        )
+
+        # Let subclasses inject product-specific arguments
+        self._add_cli_arguments(parser)
+
+        args = parser.parse_args(argv)
+
+        # Let subclasses process their own parsed arguments
+        self._configure_from_cli(args)
+
+        cors_origins = None
+        if args.cors_origins:
+            cors_origins = [origin.strip() for origin in args.cors_origins.split(",")]
+
+        if args.transport == "stdio":
+            asyncio.run(self.run_async())
+        elif args.transport == "http":
+            middleware = None
+            if cors_origins is not None:
+                from starlette.middleware import Middleware
+                from starlette.middleware.cors import CORSMiddleware
+
+                middleware = [Middleware(CORSMiddleware, allow_origins=cors_origins)]
+            asyncio.run(
+                self.run_http_async(
+                    transport="http",
+                    host=args.http_host,
+                    port=args.http_port,
+                    middleware=middleware,
+                )
+            )
+
+    def _add_cli_arguments(self, parser: argparse.ArgumentParser) -> None:
+        """Add product-specific CLI arguments to the argument parser.
+
+        Override this method in subclasses to extend the CLI provided by
+        :meth:`run_cli` with arguments specific to your product, without
+        rewriting transport dispatch logic.
+
+        Parameters
+        ----------
+        parser : argparse.ArgumentParser
+            The argument parser already populated with the standard transport
+            arguments (``--transport``, ``--http-host``, ``--http-port``,
+            ``--cors-origins``). Add your own arguments directly to it.
+
+        Examples
+        --------
+        >>> class PyMAPDLMCP(PyAnsysBaseMCP):
+        ...     def _add_cli_arguments(self, parser):
+        ...         parser.add_argument(
+        ...             "--ip",
+        ...             dest="mapdl_ip",
+        ...             default="127.0.0.1",
+        ...             help="MAPDL IP or hostname",
+        ...         )
+        ...         parser.add_argument(
+        ...             "--port",
+        ...             dest="mapdl_port",
+        ...             type=int,
+        ...             default=50052,
+        ...             help="MAPDL gRPC port",
+        ...         )
+        ...         parser.add_argument(
+        ...             "--connect-on-startup",
+        ...             dest="connect_on_startup",
+        ...             action="store_true",
+        ...             help="Connect to MAPDL during MCP startup",
+        ...         )
+
+        """
+
+    def _configure_from_cli(self, args: argparse.Namespace) -> None:
+        """Process parsed CLI arguments before the server starts.
+
+        Override this method in subclasses to react to product-specific
+        arguments added via :meth:`_add_cli_arguments`. Typical uses include
+        storing values in ``self._cli_config`` so that :meth:`create_context`
+        can read them, or disabling tools based on the parsed flags.
+
+        Parameters
+        ----------
+        args : argparse.Namespace
+            The fully parsed namespace, containing both the standard transport
+            arguments and any product-specific arguments added by
+            :meth:`_add_cli_arguments`.
+
+        Examples
+        --------
+        >>> class PyMAPDLMCP(PyAnsysBaseMCP):
+        ...     def _configure_from_cli(self, args):
+        ...         self._cli_config = {
+        ...             "mapdl_ip": args.mapdl_ip,
+        ...             "mapdl_port": args.mapdl_port,
+        ...             "connect_on_startup": args.connect_on_startup,
+        ...         }
+
+        """

--- a/tests/test_pyexample/test_main.py
+++ b/tests/test_pyexample/test_main.py
@@ -1,0 +1,171 @@
+# Copyright (C) 2025 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the PyExample MCP server entry point (``__main__.py``)."""
+
+from unittest.mock import patch
+
+from pyexample_mcp import app
+from pyexample_mcp.__main__ import main
+import pytest
+
+
+class TestMain:
+    """Tests for the ``main()`` entry point."""
+
+    def test_main_returns_zero(self):
+        """Test that main() returns 0 after a successful run."""
+        with patch.object(app, "run_cli") as mock_run_cli:
+            result = main([])
+            assert result == 0
+            mock_run_cli.assert_called_once_with([])
+
+    def test_main_passes_argv_to_run_cli(self):
+        """Test that main() forwards its argv argument to run_cli()."""
+        argv = ["--transport", "http", "--http-port", "9000"]
+        with patch.object(app, "run_cli") as mock_run_cli:
+            main(argv)
+            mock_run_cli.assert_called_once_with(argv)
+
+    def test_main_passes_none_argv_by_default(self):
+        """Test that main() passes None to run_cli() when called without arguments."""
+        with patch.object(app, "run_cli") as mock_run_cli:
+            main()
+            mock_run_cli.assert_called_once_with(None)
+
+    def test_main_sets_up_logging(self):
+        """Test that main() calls setup_logging before run_cli()."""
+        call_order = []
+
+        with patch(
+            "pyexample_mcp.__main__.setup_logging",
+            side_effect=lambda **_: call_order.append("logging"),
+        ) as mock_logging:
+            with patch.object(app, "run_cli", side_effect=lambda _: call_order.append("run_cli")):
+                main([])
+
+        mock_logging.assert_called_once_with(level="INFO")
+        assert call_order == ["logging", "run_cli"]
+
+
+class TestMainCliDispatch:
+    """Tests verifying that CLI arguments reach run_cli() correctly via main()."""
+
+    def test_stdio_transport(self):
+        """Test that stdio transport args are forwarded."""
+        with patch.object(app, "run_async", return_value=None) as mock_run:
+            with patch("ansys.common.mcp.server.asyncio.run"):
+                main(["--transport", "stdio"])
+                mock_run.assert_called_once()
+
+    def test_http_transport_default_host_and_port(self):
+        """Test that HTTP transport uses default host and port when not specified."""
+        with patch.object(app, "run_http_async", return_value=None) as mock_http:
+            with patch("ansys.common.mcp.server.asyncio.run"):
+                main(["--transport", "http"])
+                mock_http.assert_called_once_with(
+                    transport="http",
+                    host="127.0.0.1",
+                    port=8080,
+                    middleware=None,
+                )
+
+    def test_http_transport_custom_host_and_port(self):
+        """Test that custom --http-host and --http-port are forwarded."""
+        with patch.object(app, "run_http_async", return_value=None) as mock_http:
+            with patch("ansys.common.mcp.server.asyncio.run"):
+                main(["--transport", "http", "--http-host", "0.0.0.0", "--http-port", "9000"])
+                mock_http.assert_called_once_with(
+                    transport="http",
+                    host="0.0.0.0",
+                    port=9000,
+                    middleware=None,
+                )
+
+    def test_http_transport_cors_origins(self):
+        """Test that --cors-origins creates a CORSMiddleware passed via middleware."""
+        from starlette.middleware.cors import CORSMiddleware
+
+        with patch.object(app, "run_http_async", return_value=None) as mock_http:
+            with patch("ansys.common.mcp.server.asyncio.run"):
+                main(
+                    [
+                        "--transport",
+                        "http",
+                        "--cors-origins",
+                        "http://localhost:3000,https://myapp.com",
+                    ]
+                )
+                mock_http.assert_called_once()
+                mw_list = mock_http.call_args.kwargs["middleware"]
+                assert len(mw_list) == 1
+                assert mw_list[0].cls is CORSMiddleware
+                assert mw_list[0].kwargs["allow_origins"] == [
+                    "http://localhost:3000",
+                    "https://myapp.com",
+                ]
+
+    def test_invalid_port_causes_system_exit(self):
+        """Test that an out-of-range port causes SystemExit."""
+        with pytest.raises(SystemExit):
+            main(["--transport", "http", "--http-port", "99999"])
+
+    def test_unknown_transport_causes_system_exit(self):
+        """Test that an unknown transport value causes SystemExit."""
+        with pytest.raises(SystemExit):
+            main(["--transport", "grpc"])
+
+
+class TestPyExampleCliHooks:
+    """Unit tests for PyExampleMCP._add_cli_arguments and _configure_from_cli."""
+
+    def test_add_cli_arguments_registers_ip(self):
+        """Test that --ip is registered and stores value in example_ip."""
+        with patch("ansys.common.mcp.server.asyncio.run"):
+            main(["--ip", "10.0.0.5"])
+        assert app._cli_config["example_ip"] == "10.0.0.5"
+
+    def test_add_cli_arguments_registers_port(self):
+        """Test that --port is registered and stored as an integer."""
+        with patch("ansys.common.mcp.server.asyncio.run"):
+            main(["--port", "50099"])
+        assert app._cli_config["example_port"] == 50099
+
+    def test_add_cli_arguments_registers_connect_on_startup_flag(self):
+        """Test that --connect-on-startup sets the flag to True."""
+        with patch("ansys.common.mcp.server.asyncio.run"):
+            main(["--connect-on-startup"])
+        assert app._cli_config["connect_on_startup"] is True
+
+    def test_configure_from_cli_defaults(self):
+        """Test that _configure_from_cli stores default values when no product args given."""
+        with patch("ansys.common.mcp.server.asyncio.run"):
+            main([])
+        assert app._cli_config == {
+            "example_ip": "127.0.0.1",
+            "example_port": 50052,
+            "connect_on_startup": False,
+        }
+
+    def test_configure_from_cli_all_product_args(self):
+        """Test that all product-specific args are stored correctly in _cli_config."""
+        with patch("ansys.common.mcp.server.asyncio.run"):
+            main(["--ip", "192.168.1.1", "--port", "12345", "--connect-on-startup"])
+        assert app._cli_config == {
+            "example_ip": "192.168.1.1",
+            "example_port": 12345,
+            "connect_on_startup": True,
+        }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -16,6 +16,7 @@
 
 """Unit tests for server module."""
 
+import argparse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -517,6 +518,215 @@ class TestPyAnsysBaseMCPNeedPython:
                     async with mcp_false.product_lifespan(mock_server):
                         pass
                     assert mcp_false.product_startup_called
+
+
+class TestValidatePort:
+    """Tests for the _validate_port helper."""
+
+    def test_valid_port(self):
+        """Test that a valid port returns an integer."""
+        from ansys.common.mcp.server import _validate_port
+
+        assert _validate_port("8080") == 8080
+        assert _validate_port("1") == 1
+        assert _validate_port("65535") == 65535
+
+    def test_port_zero_raises(self):
+        """Test that port 0 raises ArgumentTypeError."""
+        import argparse
+
+        from ansys.common.mcp.server import _validate_port
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_port("0")
+
+    def test_port_too_large_raises(self):
+        """Test that a port above 65535 raises ArgumentTypeError."""
+        import argparse
+
+        from ansys.common.mcp.server import _validate_port
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_port("65536")
+
+    def test_non_integer_raises(self):
+        """Test that a non-integer value raises ArgumentTypeError."""
+        import argparse
+
+        from ansys.common.mcp.server import _validate_port
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_port("not-a-port")
+
+
+class TestRunCli:
+    """Tests for PyAnsysBaseMCP.run_cli()."""
+
+    def test_run_cli_stdio_default(self):
+        """Test that run_cli dispatches to run_async for stdio (default)."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "run_async", return_value=None) as mock_run:
+                with patch("ansys.common.mcp.server.asyncio.run") as mock_asyncio:
+                    mcp.run_cli([])
+
+                    mock_asyncio.assert_called_once()
+                    mock_run.assert_called_once()
+
+    def test_run_cli_explicit_stdio(self):
+        """Test that --transport stdio dispatches to run_async."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "run_async", return_value=None) as mock_run:
+                with patch("ansys.common.mcp.server.asyncio.run"):
+                    mcp.run_cli(["--transport", "stdio"])
+
+                    mock_run.assert_called_once()
+
+    def test_run_cli_http_dispatches_run_http_async(self):
+        """Test that --transport http dispatches to run_http_async without middleware."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "run_http_async", return_value=None) as mock_http:
+                with patch("ansys.common.mcp.server.asyncio.run"):
+                    mcp.run_cli(["--transport", "http"])
+
+                    mock_http.assert_called_once_with(
+                        transport="http",
+                        host="127.0.0.1",
+                        port=8080,
+                        middleware=None,
+                    )
+
+    def test_run_cli_http_custom_host_and_port(self):
+        """Test that custom --http-host and --http-port are forwarded."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "run_http_async", return_value=None) as mock_http:
+                with patch("ansys.common.mcp.server.asyncio.run"):
+                    mcp.run_cli(
+                        ["--transport", "http", "--http-host", "0.0.0.0", "--http-port", "9000"]
+                    )
+
+                    mock_http.assert_called_once_with(
+                        transport="http",
+                        host="0.0.0.0",
+                        port=9000,
+                        middleware=None,
+                    )
+
+    def test_run_cli_http_cors_origins_creates_middleware(self):
+        """Test that --cors-origins builds a CORSMiddleware and passes it via middleware."""
+        from starlette.middleware.cors import CORSMiddleware
+
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "run_http_async", return_value=None) as mock_http:
+                with patch("ansys.common.mcp.server.asyncio.run"):
+                    mcp.run_cli(
+                        [
+                            "--transport",
+                            "http",
+                            "--cors-origins",
+                            "http://localhost:3000,https://myapp.com",
+                        ]
+                    )
+
+                    mock_http.assert_called_once()
+                    call_kwargs = mock_http.call_args.kwargs
+                    assert call_kwargs["transport"] == "http"
+                    assert call_kwargs["host"] == "127.0.0.1"
+                    assert call_kwargs["port"] == 8080
+                    mw_list = call_kwargs["middleware"]
+                    assert len(mw_list) == 1
+                    assert mw_list[0].cls is CORSMiddleware
+                    assert mw_list[0].kwargs["allow_origins"] == [
+                        "http://localhost:3000",
+                        "https://myapp.com",
+                    ]
+
+    def test_run_cli_invalid_port_exits(self):
+        """Test that an out-of-range port causes SystemExit."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with pytest.raises(SystemExit):
+                mcp.run_cli(["--transport", "http", "--http-port", "99999"])
+
+    def test_run_cli_invalid_transport_exits(self):
+        """Test that an unknown transport value causes SystemExit."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with pytest.raises(SystemExit):
+                mcp.run_cli(["--transport", "grpc"])
+
+    def test_add_cli_arguments_is_called(self):
+        """Test that _add_cli_arguments is invoked with the parser."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "_add_cli_arguments") as mock_add:
+                with patch.object(mcp, "run_async", return_value=None):
+                    with patch("ansys.common.mcp.server.asyncio.run"):
+                        mcp.run_cli([])
+                mock_add.assert_called_once()
+                assert isinstance(mock_add.call_args[0][0], argparse.ArgumentParser)
+
+    def test_configure_from_cli_is_called_with_namespace(self):
+        """Test that _configure_from_cli is invoked with the parsed namespace."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            with patch.object(mcp, "_configure_from_cli") as mock_cfg:
+                with patch.object(mcp, "run_async", return_value=None):
+                    with patch("ansys.common.mcp.server.asyncio.run"):
+                        mcp.run_cli(["--transport", "stdio"])
+                mock_cfg.assert_called_once()
+                ns = mock_cfg.call_args[0][0]
+                assert isinstance(ns, argparse.Namespace)
+                assert ns.transport == "stdio"
+
+    def test_product_specific_argument_injected_via_hook(self):
+        """Test end-to-end: a subclass adds --my-flag and reads it in _configure_from_cli."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+
+            class ExtendedMCP(MockMCP):
+                captured_args = None
+
+                def _add_cli_arguments(self, parser):
+                    parser.add_argument("--my-flag", dest="my_flag", default="default_value")
+
+                def _configure_from_cli(self, args):
+                    ExtendedMCP.captured_args = args
+
+            mcp = ExtendedMCP()
+            with patch.object(mcp, "run_async", return_value=None):
+                with patch("ansys.common.mcp.server.asyncio.run"):
+                    mcp.run_cli(["--my-flag", "custom_value"])
+
+            assert ExtendedMCP.captured_args is not None
+            assert ExtendedMCP.captured_args.my_flag == "custom_value"
+
+    def test_default_add_cli_arguments_is_noop(self):
+        """Test that the default _add_cli_arguments does nothing."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            parser = argparse.ArgumentParser()
+            before = set(vars(parser.parse_args([])).keys())
+            mcp._add_cli_arguments(parser)
+            after = set(vars(parser.parse_args([])).keys())
+            assert before == after
+
+    def test_default_configure_from_cli_is_noop(self):
+        """Test that the default _configure_from_cli does nothing."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            ns = argparse.Namespace(transport="stdio")
+            # Should not raise and should not modify the server
+            mcp._configure_from_cli(ns)
+
+    def test_cli_config_initialized_as_empty_dict(self):
+        """Test that _cli_config is always initialized as an empty dict."""
+        with patch("ansys.common.mcp.server.FastMCP.__init__", return_value=None):
+            mcp = MockMCP()
+            assert mcp._cli_config == {}
 
     @pytest.mark.asyncio
     async def test_lifespan_always_calls_product_cleanup_regardless_of_need_python(self):


### PR DESCRIPTION
This PR adds ``run_cli()`` method to ``PyAnsysBaseMCP`` class so downstream packages don't need to write their own transport dispatch. 

Calling ``app.run_cli(argv)`` from ``__main__.py`` is now enough to support both stdio and HTTP out of the box.

This PR closes #115 