### PR TITLE
fix: dependencies

### DIFF
--- a/doc/changelog.d/142.fixed.md
+++ b/doc/changelog.d/142.fixed.md
@@ -1,0 +1,1 @@
+Dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,13 @@ classifiers = [
 
 dependencies = [
     "mcp>=0.1.0",
-    "fastmcp>=0.1.0"
+    "fastmcp>=3.0.0",
+    "pydantic-settings>=2.0.0",
 ]
 
 [project.optional-dependencies]
 tests = [
+    "pydantic-settings==2.14.2",
     "pytest==9.1.1",
     "pytest-asyncio==1.4.0",
     "pytest-cov==7.1.0",
@@ -61,6 +63,7 @@ doc = [
     "numpydoc==1.10.0",
     "pandas==3.0.3",
     "parse==1.22.1",
+    "pydantic-settings==2.14.2",
     "pypandoc==1.17",
     "pytest-sphinx==0.7.1",
     "regex==2026.7.10",


### PR DESCRIPTION
CICD is failing with the following error:

```
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File ".../fastmcp/__init__.py", line 8, in <module>
      from fastmcp.settings import Settings
    File ".../fastmcp/settings.py", line 11, in <module>
      from pydantic_settings import (
  ModuleNotFoundError: No module named 'pydantic_settings'
```